### PR TITLE
add country based badsurface speed limits

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/profiles/Country.java
+++ b/core/src/main/java/com/graphhopper/routing/profiles/Country.java
@@ -21,7 +21,7 @@ package com.graphhopper.routing.profiles;
  * This enum defines a country value that can be stored per edge.
  */
 public enum Country {
-    DEFAULT("default"), DEU("deu"), AUT("aut");
+    DEFAULT("default"), DEU("deu"), AUT("aut"), NAM("nam");
     public static final String KEY = "country";
 
     private final String name;

--- a/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
+++ b/core/src/main/java/com/graphhopper/routing/util/CarFlagEncoder.java
@@ -25,6 +25,8 @@ import com.graphhopper.storage.IntsRef;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.PMap;
 
+import com.graphhopper.routing.util.spatialrules.SpatialRule;
+
 import java.util.*;
 
 /**
@@ -346,9 +348,19 @@ public class CarFlagEncoder extends AbstractFlagEncoder {
      * @return The assumed speed
      */
     protected double applyBadSurfaceSpeed(ReaderWay way, double speed) {
+
+        double currentBadSurfaceSpeed = badSurfaceSpeed;
+        SpatialRule spatialRule = way.getTag("spatial_rule", null);
+
+        if (spatialRule != null) {
+            currentBadSurfaceSpeed = spatialRule.getBadSurfaceSpeed(badSurfaceSpeed);
+        }
+
         // limit speed if bad surface
-        if (badSurfaceSpeed > 0 && speed > badSurfaceSpeed && way.hasTag("surface", badSurfaceSpeedMap))
-            speed = badSurfaceSpeed;
+        if (currentBadSurfaceSpeed > 0 && speed > currentBadSurfaceSpeed && way.hasTag("surface", badSurfaceSpeedMap)) {
+            speed = currentBadSurfaceSpeed;
+        }
+
         return speed;
     }
 

--- a/core/src/main/java/com/graphhopper/routing/util/spatialrules/CountriesSpatialRuleFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/spatialrules/CountriesSpatialRuleFactory.java
@@ -2,6 +2,7 @@ package com.graphhopper.routing.util.spatialrules;
 
 import com.graphhopper.routing.util.spatialrules.countries.AustriaSpatialRule;
 import com.graphhopper.routing.util.spatialrules.countries.GermanySpatialRule;
+import com.graphhopper.routing.util.spatialrules.countries.NamibiaSpatialRule;
 import com.graphhopper.util.shapes.Polygon;
 
 import java.util.List;
@@ -18,6 +19,11 @@ public class CountriesSpatialRuleFactory implements SpatialRuleLookupBuilder.Spa
                 GermanySpatialRule germanySpatialRule = new GermanySpatialRule();
                 germanySpatialRule.setBorders(polygons);
                 return germanySpatialRule;
+            case "NAM":
+                NamibiaSpatialRule namibiaSpatialRule = new NamibiaSpatialRule();
+                namibiaSpatialRule.setBorders(polygons);
+                return namibiaSpatialRule;
+
         }
         return SpatialRule.EMPTY;
     }

--- a/core/src/main/java/com/graphhopper/routing/util/spatialrules/DefaultSpatialRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/spatialrules/DefaultSpatialRule.java
@@ -70,6 +70,11 @@ public class DefaultSpatialRule extends AbstractSpatialRule {
     }
 
     @Override
+    public double getBadSurfaceSpeed(double _default) {
+        return _default;
+    }
+
+    @Override
     public String getId() {
         throw new UnsupportedOperationException("No id for the DefaultSpatialRule");
     }

--- a/core/src/main/java/com/graphhopper/routing/util/spatialrules/SpatialRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/spatialrules/SpatialRule.java
@@ -51,6 +51,8 @@ public interface SpatialRule {
      */
     RoadAccess getAccess(String highwayTag, TransportationMode transportationMode, RoadAccess _default);
 
+    double getBadSurfaceSpeed(double _default);
+
     /**
      * Returns the borders in which the SpatialRule is valid
      */
@@ -87,5 +89,11 @@ public interface SpatialRule {
         public String toString() {
             return "SpatialRule.EMPTY";
         }
+
+        @Override
+        public double getBadSurfaceSpeed(double _default) {
+            return _default;
+        }
+
     };
 }

--- a/core/src/main/java/com/graphhopper/routing/util/spatialrules/countries/NamibiaSpatialRule.java
+++ b/core/src/main/java/com/graphhopper/routing/util/spatialrules/countries/NamibiaSpatialRule.java
@@ -1,0 +1,51 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.spatialrules.countries;
+
+import com.graphhopper.routing.profiles.Country;
+import com.graphhopper.routing.profiles.RoadAccess;
+import com.graphhopper.routing.util.spatialrules.DefaultSpatialRule;
+import com.graphhopper.routing.util.spatialrules.TransportationMode;
+
+/**
+ * Defines the default rules for Namibia roads
+ *
+ * @author Robert Wolf
+ */
+public class NamibiaSpatialRule extends DefaultSpatialRule {
+
+    @Override
+    public double getMaxSpeed(String highwayTag, double _default) {
+        return super.getMaxSpeed(highwayTag, _default);
+    }
+
+    @Override
+    public RoadAccess getAccess(String highwayTag, TransportationMode transportationMode, RoadAccess _default) {
+        return super.getAccess(highwayTag, transportationMode, _default);
+    }
+
+    @Override
+    public double getBadSurfaceSpeed(double _default) {
+        return 60;
+    }
+
+    @Override
+    public String getId() {
+        return Country.NAM.toString();
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupArrayTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/spatialrules/SpatialRuleLookupArrayTest.java
@@ -179,6 +179,11 @@ public class SpatialRuleLookupArrayTest {
             }
 
             @Override
+            public double getBadSurfaceSpeed(double _default) {
+                return _default;
+            }
+
+            @Override
             public String getId() {
                 return name;
             }


### PR DESCRIPTION
## Context/Change

In Namibia, we have a way higher speed on bad surface roads than in other countries. At the moment there is no standard way to define this on the country level. This is why I had to extend their spatial rules (geo bound rules) with a bad surface method which allows us now to overwrite the default bad surface speed. Keep in mind this is not fixing the private road problem.

### Checklist

- [ ] Ensure you have written good tests :heart:
- [ ] Request reviewers (they would love to see your code :policeman:)
- [ ] Use labels  🏷  (if applicable)

## Reference

TV-213
